### PR TITLE
Add API simple authentication for REST routes

### DIFF
--- a/.env
+++ b/.env
@@ -12,3 +12,7 @@ DB_NAME_SAMPLE=hockey_blast_sample
 
 DB_USER_BOSS=boss
 DB_PASSWORD_BOSS=boss
+
+# API key used for securing REST API endpoints
+# Replace this value with your own secure secret in production!
+API_KEY=p9TrQy9rAu74U2tL4dQzK5kVc8jH1z

--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -1,0 +1,33 @@
+# Hockey-Blast REST API – v1
+
+This document explains how to call the **v1** REST endpoints that are exposed through the `rest_api` blueprint (mounted in `blueprints/rest_api.py`) and protected by a simple **API-key** scheme.
+
+---
+
+## Authentication – API Key
+
+| Property | Value |
+|----------|-------|
+| Header name | `X-API-KEY` |
+| Type | `apiKey` (sent in `header`) |
+| Where is the valid key stored? | • `API_KEY` environment variable<br>• or `app.config['API_KEY']` |
+
+**How it works**
+
+1. Every request handled by the REST API passes through the `require_api_key` decorator.
+2. The decorator compares the value of the `X-API-KEY` header with the expected key loaded at application start-up.
+3. If the header is missing or the value does not match, the server responds with **HTTP 401 Unauthorized**.
+
+**Setting the key**
+
+```bash
+# .env (recommended – never commit to VCS)
+API_KEY=my-super-secret-key
+```
+
+or
+
+```python
+# During app/bootstrap code
+app.config['API_KEY'] = 'my-super-secret-key'
+```

--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import logging
 from flask import Flask, render_template, request, g, jsonify, send_from_directory, url_for, redirect
-from flask_restx import Api
 from flask_sqlalchemy import SQLAlchemy
 from threading import Thread
 from hockey_blast_common_lib.models import db, Organization, Game, Human, RequestLog, Team, HumanAlias
@@ -49,10 +48,7 @@ from blueprints.penalties import penalties_bp
 from blueprints.skater_performance import skater_performance_bp
 from blueprints.goalie_performance import goalie_performance_bp
 from blueprints.request_logs import request_logs_bp
-
-from api.v1.organizations import organizations_ns
-from api.v1.divisions import divisions_ns
-from api.v1.seasons import seasons_ns
+from blueprints.rest_api import rest_api_bp
 
 # BLOCKED_USER_AGENT = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.6834.83 Mobile Safari/537.36 (compatible; GoogleOther)"
 # BLOCKED_IPS = ["66.249.72.103", "66.249.72.204"]
@@ -97,6 +93,8 @@ def create_app(db_name):
     app.register_blueprint(skater_performance_bp, url_prefix='/skater_performance')
     app.register_blueprint(goalie_performance_bp, url_prefix='/goalie_performance')
     app.register_blueprint(request_logs_bp, url_prefix='/request_logs')
+    # REST API blueprint (provides /swagger and /api/v1/* routes)
+    app.register_blueprint(rest_api_bp)
 
     @app.before_request
     def before_request():
@@ -228,18 +226,6 @@ def create_app(db_name):
     @app.route('/about')
     def about():
         return render_template('about.html')
-
-    api = Api(
-        app,
-        version='1.0',
-        title='Hockey BLAST API',
-        description='RESTful API',
-        doc='/swagger'
-    )
-
-    api.add_namespace(organizations_ns, path='/api/v1')
-    api.add_namespace(divisions_ns, path='/api/v1')
-    api.add_namespace(seasons_ns, path='/api/v1')
 
     return app
 

--- a/app.py
+++ b/app.py
@@ -70,6 +70,8 @@ def create_app(db_name):
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['BACKGROUND_IMAGE'] = 'default_background.jpg'
     app.config['ORG_NAME'] = 'Hockey Blast'
+    # API key configuration (environment variable takes precedence)
+    app.config['API_KEY'] = os.environ.get('API_KEY', 'CHANGE_ME')
     db.init_app(app)
 
     # Register blueprints

--- a/blueprints/rest_api.py
+++ b/blueprints/rest_api.py
@@ -1,4 +1,6 @@
-from flask import Blueprint
+import os
+from functools import wraps
+from flask import Blueprint, request, abort, current_app
 from flask_restx import Api
 
 # Import all namespaces from api/v1
@@ -12,14 +14,48 @@ rest_api_bp = Blueprint('rest_api', __name__)
 def index():
   return 'rest api root'
 
-# Attach a fully-featured Api object to this blueprint and
+# ------------------------------------------------------------------------------
+# API-key authentication setup
+# ------------------------------------------------------------------------------
+
+# Swagger / OpenAPI security scheme
+authorizations = {
+    'apikey': {
+        'type': 'apiKey',
+        'in': 'header',
+        'name': 'X-API-KEY'
+    }
+}
+
+def require_api_key(func):
+    """
+    Simple decorator to enforce an API key on every request handled by this
+    blueprint's Api.  Expects the client to send the key in the `X-API-KEY`
+    request header.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        provided_key = request.headers.get('X-API-KEY')
+        # Prefer key from app config, fall back to environment variable
+        expected_key = current_app.config.get('API_KEY') or os.environ.get('API_KEY')
+        if expected_key and provided_key == expected_key:
+            return func(*args, **kwargs)
+        abort(401, 'Invalid or missing API key')
+
+    return wrapper
+
+# ------------------------------------------------------------------------------
+# Attach a fully-featured Api object to this blueprint and register namespaces
 # register the imported namespaces under the common prefix.
 api = Api(
     rest_api_bp,
     version='1.0',
     title='Hockey BLAST API',
     description='RESTful API',
-    doc='/swagger'  # Swagger UI served at /swagger relative to blueprint
+    doc='/swagger',  # Swagger UI served at /swagger relative to blueprint
+    authorizations=authorizations,
+    security='apikey',
+    decorators=[require_api_key],  # Enforce auth globally
 )
 
 # Register namespaces

--- a/blueprints/rest_api.py
+++ b/blueprints/rest_api.py
@@ -1,5 +1,10 @@
-from flask import Blueprint, render_template
+from flask import Blueprint
 from flask_restx import Api
+
+# Import all namespaces from api/v1
+from api.v1.organizations import organizations_ns
+from api.v1.divisions import divisions_ns
+from api.v1.seasons import seasons_ns
 
 rest_api_bp = Blueprint('rest_api', __name__)
 
@@ -7,5 +12,17 @@ rest_api_bp = Blueprint('rest_api', __name__)
 def index():
   return 'rest api root'
 
-api = Api(rest_api_bp, doc=False)
+# Attach a fully-featured Api object to this blueprint and
+# register the imported namespaces under the common prefix.
+api = Api(
+    rest_api_bp,
+    version='1.0',
+    title='Hockey BLAST API',
+    description='RESTful API',
+    doc='/swagger'  # Swagger UI served at /swagger relative to blueprint
+)
 
+# Register namespaces
+api.add_namespace(organizations_ns, path='/api/v1')
+api.add_namespace(divisions_ns, path='/api/v1')
+api.add_namespace(seasons_ns, path='/api/v1')


### PR DESCRIPTION
I've been toying with generative AI to see how much I can get done with a few commands!

* Reroute all `api/v1/` namespaces to be registered in `blueprints/rest_api.py`
* Added simple authentication for routes registered in `rest_api.py`
* The API key is currently in `.env`, feel free to move it or remove it